### PR TITLE
Release 0.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@master
-        name: Setup Python 3.8
+        name: Setup Python 3.10
         with:
-          python-version: 3.8
+          python-version: 3.10
 
       - name: Install dependencies
         run: python -m pip install -U poetry

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
         experimental: [false]
         include:
           - python-version: "3.11-dev"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
         experimental: [false]
         include:
           - python-version: "3.11-dev"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python: Asynchronous client for Combined Energy API
 
-Provides an async Python 3.10+ interface for the http://combined.energy/ monitoring platform API.
+Provides an async Python 3.8+ interface for the http://combined.energy/ monitoring platform API.
 
 > Note this API client is reverse engineered from observing requests being made  
 > in the web-application. Please report any failures to read data, this is likely
@@ -49,5 +49,5 @@ asyncio.run(main())
 
 You will need:
 
-- Python 3.10+
+- Python 3.8+
 - poetry

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python: Asynchronous client for Combined Energy API
 
-Provides an async Python 3.8+ interface for the http://combined.energy/ monitoring platform API.
+Provides an async Python 3.10+ interface for the http://combined.energy/ monitoring platform API.
 
 > Note this API client is reverse engineered from observing requests being made  
 > in the web-application. Please report any failures to read data, this is likely
@@ -49,5 +49,5 @@ asyncio.run(main())
 
 You will need:
 
-- Python 3.8+
+- Python 3.10+
 - poetry

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ Provides an async Python 3.8+ interface for the http://combined.energy/ monitori
 
 ## Installation
 
-This package is currently only available from source
+Install from PyPI
+
+```shell
+python3 -m pip install combined-energy-api
+```
 
 ## Usage
 

--- a/example/readings.py
+++ b/example/readings.py
@@ -1,13 +1,17 @@
 # Example that reads the communication status and fetches readings
 import asyncio
+import logging
 import os
 
 from combined_energy.client import CombinedEnergy
+from combined_energy.helpers import ReadingsIterator
 
 INSTALL_ID = int(os.getenv("CE_INSTALL_ID", 0))
 
 
 async def main():
+    logging.basicConfig(level=logging.DEBUG)
+
     async with CombinedEnergy(
         mobile_or_email=os.getenv("CE_EMAIL", "user@example.com"),
         password=os.getenv("CE_PASSWORD", "PASSWORD"),
@@ -16,9 +20,12 @@ async def main():
         com_stat = await combined_energy.communication_status()
         print(com_stat)
 
-        readings = await combined_energy.last_readings(minutes=15, increment=5)
-        for device in readings.devices:
-            print(device)
+        async for readings in ReadingsIterator(combined_energy, increment=5):
+            print(
+                f"{readings.range_start} - {readings.range_end}: {readings.range_count}"
+            )
+
+            await asyncio.sleep(5)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.10"
 aiohttp = "*"
 pydantic = "*"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.8"
 aiohttp = "*"
 pydantic = "*"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "combined-energy-api"
-version = "0.2"
+version = "0.3"
 description = "Python interface to the Combined Energy API"
 authors = ["Tim Savage <tim@savage.company>"]
 maintainers = ["Tim Savage <tim@savage.company>"]

--- a/src/combined_energy/client.py
+++ b/src/combined_energy/client.py
@@ -43,7 +43,7 @@ class CombinedEnergy:
 
     # Configuration Options
     expiry_window: int = 300
-    request_timeout: float = 8.0
+    request_timeout: float = 10.0
 
     # State
     session: Optional[ClientSession] = None
@@ -275,12 +275,13 @@ class CombinedEnergy:
                     "jwt": self._jwt,
                 },
                 method=METH_POST,
-                request_timeout=30.0,
             )
             return data.get("status") == "ok"
 
-        except exceptions.CombinedEnergyTimeoutError:
-            print(self.session)
+        except exceptions.CombinedEnergyTimeoutError as ex:
+            # Not sure why this particular request consistently times out, ignoring
+            # the response brings it back to life
+            LOGGER.warning("LogSessionStart request timed out with: %s", ex)
             return True  # Assume ok
 
     async def close(self) -> None:

--- a/src/combined_energy/helpers.py
+++ b/src/combined_energy/helpers.py
@@ -1,0 +1,72 @@
+import logging
+from collections import deque
+from datetime import datetime, timedelta
+from typing import Optional, AsyncIterator
+
+from .client import CombinedEnergy
+from .models import Readings
+
+LOGGER = logging.getLogger(__package__)
+
+now = datetime.now
+
+
+class ReadingsIterator:
+    """
+    Iterator that returns readings with a certain interval specified
+    """
+
+    __slots__ = ("client", "increment", "initial_delta", "_last_end", "_empty")
+
+    def __init__(
+        self,
+        client: CombinedEnergy,
+        *,
+        increment: int,
+        initial_delta: timedelta = None,
+        log_session_reset_count: int = 3
+    ):
+        self.client = client
+        self.increment = increment
+        self.initial_delta = initial_delta
+
+        self._last_end: Optional[datetime] = None
+        # Prefill with False
+        self._empty = deque([False] * log_session_reset_count, log_session_reset_count)
+
+    @property
+    def next_range_start(self) -> Optional[datetime]:
+        """
+        Calculate the next range start value
+        """
+        if self._last_end:
+            return self._last_end
+        if self.initial_delta:
+            return now() - self.initial_delta
+
+    async def _check_for_log_session_restart(self):
+        """
+        Check if a start log session message is required.
+
+        This is a strange behaviour of this API that requires the client to
+        call start new log session. In the dashboard app this is covered up
+        with a dialog that pops up periodically.
+        """
+        # Reset if deque is full of True statuses
+        if all(self._empty):
+            LOGGER.info("Restart log session...")
+            await self.client.start_log_session()
+
+    async def __aiter__(self) -> AsyncIterator[Readings]:
+        while True:
+            await self._check_for_log_session_restart()
+
+            readings = await self.client.readings(
+                self.next_range_start, None, self.increment
+            )
+
+            # Update state
+            self._empty.append(readings.range_count == 0)
+            self._last_end = readings.range_end
+
+            yield readings

--- a/src/combined_energy/models.py
+++ b/src/combined_energy/models.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Dict, Literal, Union
 from pydantic import BaseModel, Field
 
 now = datetime.now
+OptionalFloatList = List[Optional[float]]
 
 
 class Login(BaseModel):
@@ -176,7 +177,7 @@ class DeviceReadings(BaseModel):
     range_start: datetime = Field(alias="rangeStart")
     range_end: datetime = Field(alias="rangeEnd")
     timestamp: List[datetime]
-    sample_seconds: List[int] = Field(alias="sampleSecs")
+    sample_seconds: Optional[List[int]] = Field(alias="sampleSecs")
 
 
 class DeviceReadingsBattery(DeviceReadings):
@@ -186,22 +187,40 @@ class DeviceReadingsBattery(DeviceReadings):
 class DeviceReadingsCombiner(DeviceReadings):
     device_type: Literal["COMBINER"] = Field(alias="deviceType")
 
-    energy_supplied: List[float] = Field(alias="energySupplied")
-    energy_supplied_solar: List[float] = Field(alias="energySuppliedSolar")
-    energy_supplied_battery: List[float] = Field(alias="energySuppliedBattery")
-    energy_supplied_grid: List[float] = Field(alias="energySuppliedGrid")
-    energy_consumed_other: List[float] = Field(alias="energyConsumedOther")
-    energy_consumed_other_solar: List[float] = Field(alias="energyConsumedOtherSolar")
-    energy_consumed_other_battery: List[float] = Field(
+    energy_supplied: Optional[OptionalFloatList] = Field(alias="energySupplied")
+    energy_supplied_solar: Optional[OptionalFloatList] = Field(
+        alias="energySuppliedSolar"
+    )
+    energy_supplied_battery: Optional[OptionalFloatList] = Field(
+        alias="energySuppliedBattery"
+    )
+    energy_supplied_grid: Optional[OptionalFloatList] = Field(
+        alias="energySuppliedGrid"
+    )
+    energy_consumed_other: Optional[OptionalFloatList] = Field(
+        alias="energyConsumedOther"
+    )
+    energy_consumed_other_solar: Optional[OptionalFloatList] = Field(
+        alias="energyConsumedOtherSolar"
+    )
+    energy_consumed_other_battery: Optional[OptionalFloatList] = Field(
         alias="energyConsumedOtherBattery"
     )
-    energy_consumed_other_grid: List[float] = Field(alias="energyConsumedOtherGrid")
-    energy_consumed: List[float] = Field(alias="energyConsumed")
-    energy_consumed_solar: List[float] = Field(alias="energyConsumedSolar")
-    energy_consumed_battery: List[float] = Field(alias="energyConsumedBattery")
-    energy_consumed_grid: List[float] = Field(alias="energyConsumedGrid")
-    energy_correction: List[int] = Field(alias="energyCorrection")
-    temperature: List[Optional[float]]
+    energy_consumed_other_grid: Optional[OptionalFloatList] = Field(
+        alias="energyConsumedOtherGrid"
+    )
+    energy_consumed: Optional[OptionalFloatList] = Field(alias="energyConsumed")
+    energy_consumed_solar: Optional[OptionalFloatList] = Field(
+        alias="energyConsumedSolar"
+    )
+    energy_consumed_battery: Optional[OptionalFloatList] = Field(
+        alias="energyConsumedBattery"
+    )
+    energy_consumed_grid: Optional[OptionalFloatList] = Field(
+        alias="energyConsumedGrid"
+    )
+    energy_correction: Optional[OptionalFloatList] = Field(alias="energyCorrection")
+    temperature: Optional[OptionalFloatList]
 
 
 class DeviceReadingsSolarPredicted(DeviceReadings):
@@ -210,10 +229,10 @@ class DeviceReadingsSolarPredicted(DeviceReadings):
 
 class DeviceReadingsSolarPV(DeviceReadings):
     device_type: Literal["SOLAR_PV"] = Field(alias="deviceType")
-    operation_status: List[str] = Field(alias="operationStatus")
-    operation_message: List[Optional[str]] = Field(alias="operationMessage")
+    operation_status: Optional[List[Optional[str]]] = Field(alias="operationStatus")
+    operation_message: Optional[List[Optional[str]]] = Field(alias="operationMessage")
 
-    energy_supplied: List[float] = Field(alias="energySupplied")
+    energy_supplied: Optional[List[float]] = Field(alias="energySupplied")
 
 
 class DeviceReadingsGridMeter(DeviceReadings):
@@ -222,13 +241,15 @@ class DeviceReadingsGridMeter(DeviceReadings):
 
 class DeviceReadingsGenericConsumer(DeviceReadings):
     device_type: Literal["GENERIC_CONSUMER"] = Field(alias="deviceType")
-    operation_status: List[str] = Field(alias="operationStatus")
-    operation_message: List[Optional[str]] = Field(alias="operationMessage")
+    operation_status: Optional[List[Optional[str]]] = Field(alias="operationStatus")
+    operation_message: Optional[List[Optional[str]]] = Field(alias="operationMessage")
 
-    energy_consumed: List[float] = Field(alias="energyConsumed")
-    energy_consumed_solar: List[float] = Field(alias="energyConsumedSolar")
-    energy_consumed_battery: List[float] = Field(alias="energyConsumedBattery")
-    energy_consumed_grid: List[float] = Field(alias="energyConsumedGrid")
+    energy_consumed: Optional[List[float]] = Field(alias="energyConsumed")
+    energy_consumed_solar: Optional[List[float]] = Field(alias="energyConsumedSolar")
+    energy_consumed_battery: Optional[List[float]] = Field(
+        alias="energyConsumedBattery"
+    )
+    energy_consumed_grid: Optional[List[float]] = Field(alias="energyConsumedGrid")
 
 
 class DeviceReadingsPoolHeater(DeviceReadings):
@@ -238,15 +259,15 @@ class DeviceReadingsPoolHeater(DeviceReadings):
 class DeviceReadingsWaterHeater(DeviceReadingsGenericConsumer):
     device_type: Literal["WATER_HEATER"] = Field(alias="deviceType")
 
-    available_energy: List[float] = Field(alias="availableEnergy")
-    max_energy: List[float] = Field(alias="maxEnergy")
-    temp_sensor1: List[float] = Field(alias="s1")
-    temp_sensor2: List[float] = Field(alias="s2")
-    temp_sensor3: List[float] = Field(alias="s3")
-    temp_sensor4: List[float] = Field(alias="s4")
-    temp_sensor5: List[float] = Field(alias="s5")
-    temp_sensor6: List[float] = Field(alias="s6")
-    water_heater_status: List[str] = Field(alias="whStatus")
+    available_energy: Optional[OptionalFloatList] = Field(alias="availableEnergy")
+    max_energy: Optional[OptionalFloatList] = Field(alias="maxEnergy")
+    temp_sensor1: Optional[OptionalFloatList] = Field(alias="s1")
+    temp_sensor2: Optional[OptionalFloatList] = Field(alias="s2")
+    temp_sensor3: Optional[OptionalFloatList] = Field(alias="s3")
+    temp_sensor4: Optional[OptionalFloatList] = Field(alias="s4")
+    temp_sensor5: Optional[OptionalFloatList] = Field(alias="s5")
+    temp_sensor6: Optional[OptionalFloatList] = Field(alias="s6")
+    water_heater_status: Optional[List[Optional[str]]] = Field(alias="whStatus")
 
 
 class DeviceReadingsEnergyBalance(DeviceReadingsGenericConsumer):

--- a/tests/fixtures/api-responses/LogSessionStart.json
+++ b/tests/fixtures/api-responses/LogSessionStart.json
@@ -1,0 +1,1 @@
+{"installationId":999998,"status":"ok","archiveSaved":true}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -271,6 +271,35 @@ class TestCombinedEnergy:
         aresponses.assert_plan_strictly_followed()
 
     @pytest.mark.asyncio
+    async def test_start_log_session__where_refresh_is_successful(
+        self, api_responses, target, aresponses
+    ):
+        aresponses.add(
+            "onwatch.combined.energy",
+            "/user/Login",
+            "POST",
+            aresponses.Response(
+                text="""{"status": "ok", "jwt": "foo", "expireMins": 30}""",
+                status=200,
+                content_type="application/json",
+            ),
+        )
+        aresponses.add(
+            "dp20.combined.energy",
+            "/mqtt2/user/LogSessionStart",
+            "POST",
+            aresponses.Response(
+                text=(api_responses / "LogSessionStart.json").read_text(),
+                status=200,
+                content_type="application/json",
+            ),
+        )
+
+        await target.start_log_session()
+
+        aresponses.assert_plan_strictly_followed()
+
+    @pytest.mark.asyncio
     async def test_request__with_permission_denied(
         self, target, aresponses, api_responses
     ):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,6 +6,15 @@ import pytest
 from combined_energy import helpers
 
 
+async def async_iter(iterable):
+    async for item in iterable:
+        yield item
+
+
+async def async_next(iterator):
+    return await iterator.__anext__()
+
+
 class TestReadingsIterator:
     def test_next_range_start__where_no_request_made(self):
         target = helpers.ReadingsIterator(
@@ -77,29 +86,29 @@ class TestReadingsIterator:
         target = helpers.ReadingsIterator(
             mock_client, increment=10, log_session_reset_count=2
         )
-        iterator = aiter(target)
+        iterator = async_iter(target)
 
         # Check first request
-        await anext(iterator)
+        await async_next(iterator)
         assert target.next_range_start == datetime(2022, 2, 22, 22, 00, 21)
         mock_client.start_log_session.assert_not_called()
 
         # Check second request
-        await anext(iterator)
+        await async_next(iterator)
         assert target.next_range_start == datetime(2022, 2, 22, 22, 00, 22)
         mock_client.start_log_session.assert_not_called()
 
         # Check third request
-        await anext(iterator)
+        await async_next(iterator)
         assert target.next_range_start == datetime(2022, 2, 22, 22, 00, 22)
         mock_client.start_log_session.assert_not_called()
 
         # Check forth request
-        await anext(iterator)
+        await async_next(iterator)
         assert target.next_range_start == datetime(2022, 2, 22, 22, 00, 22)
         mock_client.start_log_session.assert_not_called()
 
         # Check fifth request
-        await anext(iterator)
+        await async_next(iterator)
         assert target.next_range_start == datetime(2022, 2, 22, 22, 00, 25)
         mock_client.start_log_session.assert_called()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,105 @@
+from datetime import datetime, timedelta
+from unittest.mock import Mock, AsyncMock
+
+import pytest
+
+from combined_energy import helpers
+
+
+class TestReadingsIterator:
+    def test_next_range_start__where_no_request_made(self):
+        target = helpers.ReadingsIterator(
+            AsyncMock(helpers.CombinedEnergy), increment=10
+        )
+
+        actual = target.next_range_start
+
+        assert actual is None
+
+    def test_next_range_start__where_successful_request_made(self):
+        target = helpers.ReadingsIterator(
+            AsyncMock(helpers.CombinedEnergy), increment=10
+        )
+        target._last_end = datetime(2022, 2, 22, 22, 22, 22)
+
+        actual = target.next_range_start
+
+        assert actual == datetime(2022, 2, 22, 22, 22, 22)
+
+    def test_next_range_start__where_timedelta_set(self, monkeypatch):
+        monkeypatch.setattr(helpers, "now", lambda: datetime(2022, 2, 22, 22, 22, 22))
+
+        target = helpers.ReadingsIterator(
+            AsyncMock(helpers.CombinedEnergy),
+            increment=10,
+            initial_delta=timedelta(minutes=22),
+        )
+
+        actual = target.next_range_start
+
+        assert actual == datetime(2022, 2, 22, 22, 00, 22)
+
+    @pytest.mark.asyncio
+    async def test_check_for_log_session_restart__check_behaviour(self):
+        mock_client = AsyncMock(helpers.CombinedEnergy)
+        target = helpers.ReadingsIterator(
+            mock_client, increment=10, log_session_reset_count=2
+        )
+
+        await target._check_for_log_session_restart()
+        mock_client.start_log_session.assert_not_called()
+
+        target._empty.append(False)
+        target._empty.append(True)
+
+        await target._check_for_log_session_restart()
+        mock_client.start_log_session.assert_not_called()
+
+        target._empty.append(True)
+
+        await target._check_for_log_session_restart()
+        mock_client.start_log_session.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_iterator(self):
+        mock_client = AsyncMock(
+            helpers.CombinedEnergy,
+            readings=AsyncMock(
+                side_effect=[
+                    Mock(range_count=1, range_end=datetime(2022, 2, 22, 22, 00, 21)),
+                    Mock(range_count=1, range_end=datetime(2022, 2, 22, 22, 00, 22)),
+                    Mock(range_count=0, range_end=datetime(2022, 2, 22, 22, 00, 22)),
+                    Mock(range_count=0, range_end=datetime(2022, 2, 22, 22, 00, 22)),
+                    Mock(range_count=3, range_end=datetime(2022, 2, 22, 22, 00, 25)),
+                ]
+            ),
+        )
+        target = helpers.ReadingsIterator(
+            mock_client, increment=10, log_session_reset_count=2
+        )
+        iterator = aiter(target)
+
+        # Check first request
+        await anext(iterator)
+        assert target.next_range_start == datetime(2022, 2, 22, 22, 00, 21)
+        mock_client.start_log_session.assert_not_called()
+
+        # Check second request
+        await anext(iterator)
+        assert target.next_range_start == datetime(2022, 2, 22, 22, 00, 22)
+        mock_client.start_log_session.assert_not_called()
+
+        # Check third request
+        await anext(iterator)
+        assert target.next_range_start == datetime(2022, 2, 22, 22, 00, 22)
+        mock_client.start_log_session.assert_not_called()
+
+        # Check forth request
+        await anext(iterator)
+        assert target.next_range_start == datetime(2022, 2, 22, 22, 00, 22)
+        mock_client.start_log_session.assert_not_called()
+
+        # Check fifth request
+        await anext(iterator)
+        assert target.next_range_start == datetime(2022, 2, 22, 22, 00, 25)
+        mock_client.start_log_session.assert_called()


### PR DESCRIPTION
- Fixes a number of issues identified in the schema largely around which fields can be null (or lists of null)
- Adds a call to _LogSessionStart_ API endpoint that is periodically required to keep report data available
- Add ReadingsIterator helper that handles calls to _LogSessionStart_ as well as the correct time ranges for requests to generate a consistent time-series data stream.