### PR TITLE
Prevent IO block reading metadata during async request

### DIFF
--- a/src/combined_energy/client.py
+++ b/src/combined_energy/client.py
@@ -1,10 +1,10 @@
 """Client for API."""
+
 from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
 import datetime
-from importlib import metadata
 import logging
 import socket
 
@@ -18,7 +18,7 @@ from aiohttp import ClientError, ClientResponseError, ClientSession
 from aiohttp.hdrs import METH_GET, METH_POST
 
 from . import exceptions
-from .constants import LOGGER
+from .constants import LOGGER, VERSION
 from .models import (
     ConnectionHistory,
     ConnectionStatus,
@@ -64,10 +64,9 @@ class CombinedEnergy:
         request_timeout: float = None,
     ):
         """Handle a request to the Combined Energy API."""
-        version = metadata.version("combined-energy-api")
         headers = {
             "Accept": accept,
-            "User-Agent": f"PythonCombinedEnergy/{version}",
+            "User-Agent": f"PythonCombinedEnergy/{VERSION}",
         }
 
         if self.session is None:

--- a/src/combined_energy/constants.py
+++ b/src/combined_energy/constants.py
@@ -1,8 +1,11 @@
 """Constants used by API."""
+
 from enum import Enum
+from importlib import metadata
 import logging
 
 LOGGER = logging.getLogger(__package__)
+VERSION = metadata.version("combined-energy-api")
 
 
 class DeviceType(str, Enum):


### PR DESCRIPTION
Every async request being made is being penalised because it is fetching metadata that is being read via blocking IO calls.

Moving the metadata fetching to occur as the module is being initialised as that operation is blocking. Also, the data only needs to be read once and then is stored in a constant for future use.
