### PR TITLE
Default whStatus to None as API no longer supplies property

### DIFF
--- a/src/combined_energy/models.py
+++ b/src/combined_energy/models.py
@@ -333,7 +333,9 @@ class DeviceReadingsWaterHeater(DeviceReadingsGenericConsumer):
     temp_sensor4: None | list[None | float] = Field(alias="s4")
     temp_sensor5: None | list[None | float] = Field(alias="s5")
     temp_sensor6: None | list[None | float] = Field(alias="s6")
-    water_heater_status: None | list[None | dict[str, Any]] = Field(alias="whStatus")
+    water_heater_status: None | list[None | dict[str, Any]] = Field(
+        alias="whStatus", default=None
+    )
 
     def __str__(self):
         """Convert instance to string."""


### PR DESCRIPTION
The API appears to no longer include `whStatus` which is causing the model to fail validation. To keep compatibility with integrations update the field to default the value to be `None`.
